### PR TITLE
Discard master-slave vocabulary

### DIFF
--- a/footmark/slb/connection.py
+++ b/footmark/slb/connection.py
@@ -301,7 +301,7 @@ class SLBConnection(ACSQueryConnection):
                                             vserver_group_id='',\
                                             gzip='',\
                                             server_certificate_id='',\
-                                            master_slave_server_group_id='',\
+                                            main_subordinate_server_group_id='',\
                                             persistence_timeout=None,\
                                             health_check_connect_timeout=None,\
                                             xforwarded_for = 'on',\
@@ -355,8 +355,8 @@ class SLBConnection(ACSQueryConnection):
         :param: gzip: whether open Gzip compression
         :type: server_certificate_id: string
         :param: server_certificate_id: Server certificate ID.
-        :type: master_slave_server_group_id: string
-        :param: master_slave_server_group_id: Master standby server group ID
+        :type: main_subordinate_server_group_id: string
+        :param: main_subordinate_server_group_id: Main standby server group ID
         :type: persistence_timeout: string
         :param: persistence_timeout: Timeout time for connection persistence.
         :type: health_check_connect_timeout: int
@@ -418,8 +418,8 @@ class SLBConnection(ACSQueryConnection):
             self.build_list_params(params, health_check_http_code, 'HealthCheckHttpCode')
         if vserver_group_id:
             self.build_list_params(params, vserver_group_id, 'VServerGroupId')
-        if master_slave_server_group_id:
-            self.build_list_params(params, master_slave_server_group_id, 'MasterSlaveServerGroupId')
+        if main_subordinate_server_group_id:
+            self.build_list_params(params, main_subordinate_server_group_id, 'MainSubordinateServerGroupId')
         if persistence_timeout:
             self.build_list_params(params, persistence_timeout, 'PersistenceTimeout')
         if health_check_connect_timeout:
@@ -470,14 +470,14 @@ class SLBConnection(ACSQueryConnection):
                                     vserver_group_id='',\
                                     gzip='',\
                                     server_certificate_id='',\
-                                    master_slave_server_group_id='',\
+                                    main_subordinate_server_group_id='',\
                                     persistence_timeout=None,\
                                     health_check_connect_timeout=None,\
                                     ca_certificate_id='',\
                                     syn_proxy='',\
                                     health_check_type='',\
                                     vserver_group='',\
-                                    master_slave_server_group='',
+                                    main_subordinate_server_group='',
                                     xforwarded_for='on'):
         """
         set listener attribute
@@ -523,8 +523,8 @@ class SLBConnection(ACSQueryConnection):
         :param: gzip: whether open Gzip compression
         :type: server_certificate_id: string
         :param: server_certificate_id: Server certificate ID.
-        :type: master_slave_server_group_id: string
-        :param: master_slave_server_group_id: Master standby server group ID
+        :type: main_subordinate_server_group_id: string
+        :param: main_subordinate_server_group_id: Main standby server group ID
         :type: persistence_timeout: string
         :param: persistence_timeout: Timeout time for connection persistence.
         :type: health_check_connect_timeout: int
@@ -539,8 +539,8 @@ class SLBConnection(ACSQueryConnection):
         :param: health_check_type: health check type
         :type: vserver_group: string
         :param: vserver_group: Whether to use a virtual server group
-        :type: master_slave_server_group: string
-        :param: master_slave_server_group: Whether to use the primary and secondary server groups
+        :type: main_subordinate_server_group: string
+        :param: main_subordinate_server_group: Whether to use the primary and secondary server groups
         :return: returns request status
         """
         params = {}
@@ -591,10 +591,10 @@ class SLBConnection(ACSQueryConnection):
             self.build_list_params(params, vserver_group, 'VServerGroup')
         if vserver_group_id:
             self.build_list_params(params, vserver_group_id, 'VServerGroupId')
-        if master_slave_server_group_id:
-            self.build_list_params(params, master_slave_server_group_id, 'MasterSlaveServerGroupId')
-        if master_slave_server_group:
-            self.build_list_params(params, master_slave_server_group, 'MasterSlaveServerGroup')
+        if main_subordinate_server_group_id:
+            self.build_list_params(params, main_subordinate_server_group_id, 'MainSubordinateServerGroupId')
+        if main_subordinate_server_group:
+            self.build_list_params(params, main_subordinate_server_group, 'MainSubordinateServerGroup')
         if ca_certificate_id:
             self.build_list_params(params, ca_certificate_id, 'CACertificateId')
         if syn_proxy:

--- a/footmark/slb/slb.py
+++ b/footmark/slb/slb.py
@@ -113,14 +113,14 @@ class LoadBalancerListener(TaggedSLBObject):
                             vserver_group_id='',\
                             gzip='',\
                             server_certificate_id='',\
-                            master_slave_server_group_id='',\
+                            main_subordinate_server_group_id='',\
                             persistence_timeout=None,\
                             health_check_connect_timeout=None,\
                             ca_certificate_id='',\
                             syn_proxy='',\
                             health_check_type='',\
                             vserver_group='',\
-                            master_slave_server_group=''):
+                            main_subordinate_server_group=''):
         '''
         set listener attribute
         '''
@@ -145,14 +145,14 @@ class LoadBalancerListener(TaggedSLBObject):
                                     vserver_group_id=vserver_group_id,\
                                     gzip=gzip,\
                                     server_certificate_id=server_certificate_id,\
-                                    master_slave_server_group_id=master_slave_server_group_id,\
+                                    main_subordinate_server_group_id=main_subordinate_server_group_id,\
                                     persistence_timeout=persistence_timeout,\
                                     health_check_connect_timeout=health_check_connect_timeout,\
                                     ca_certificate_id=ca_certificate_id,\
                                     syn_proxy=syn_proxy,\
                                     health_check_type=health_check_type,\
                                     vserver_group=vserver_group,\
-                                    master_slave_server_group=master_slave_server_group)
+                                    main_subordinate_server_group=main_subordinate_server_group)
     
     def remove_white_list_item(self, load_balancer_id, source_items):
         '''

--- a/tests/unit/slb/test_instance.py
+++ b/tests/unit/slb/test_instance.py
@@ -268,8 +268,8 @@ class TestCreateLoadBalancer(ACSMockServiceTestCase):
     internet_charge_type = None
     bandwidth = None
     vswitch_id = None
-    master_zone_id = "cn-beijing-b"
-    slave_zone_id = "cn-beijing-a"
+    main_zone_id = "cn-beijing-b"
+    subordinate_zone_id = "cn-beijing-a"
     instance_ids = None
     validate_cert = None
     tags = None
@@ -285,8 +285,8 @@ class TestCreateLoadBalancer(ACSMockServiceTestCase):
                                                                        address_type=self.address_type,
                                                                        vswitch_id=self.vswitch_id,
                                                                        internet_charge_type=self.internet_charge_type,
-                                                                       master_zone_id=self.master_zone_id,
-                                                                       slave_zone_id=self.slave_zone_id,
+                                                                       main_zone_id=self.main_zone_id,
+                                                                       subordinate_zone_id=self.subordinate_zone_id,
                                                                        bandwidth=self.bandwidth,
                                                                        listeners=self.listeners,
                                                                        instance_ids=self.instance_ids,


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.